### PR TITLE
fix(@arbitrum/sdk): patch L1ToL2MessageGasEstimator to handle Metamas…

### DIFF
--- a/webapps/world-builder-dashboard/patches/@arbitrum+sdk+3.4.1.patch
+++ b/webapps/world-builder-dashboard/patches/@arbitrum+sdk+3.4.1.patch
@@ -1,9 +1,8 @@
 diff --git a/node_modules/@arbitrum/sdk/dist/lib/.DS_Store b/node_modules/@arbitrum/sdk/dist/lib/.DS_Store
 new file mode 100644
-index 0000000..7714cb7
-Binary files /dev/null and b/node_modules/@arbitrum/sdk/dist/lib/.DS_Store differ
+index 0000000..e69de29
 diff --git a/node_modules/@arbitrum/sdk/dist/lib/assetBridger/erc20Bridger.js b/node_modules/@arbitrum/sdk/dist/lib/assetBridger/erc20Bridger.js
-index 482fbe1..c774b68 100644
+index 482fbe1..c8ce8b7 100644
 --- a/node_modules/@arbitrum/sdk/dist/lib/assetBridger/erc20Bridger.js
 +++ b/node_modules/@arbitrum/sdk/dist/lib/assetBridger/erc20Bridger.js
 @@ -410,7 +410,7 @@ class Erc20Bridger extends assetBridger_1.AssetBridger {
@@ -62,3 +61,20 @@ index 6935967..60443ec 100644
  };
  /**
   * Determines if a chain is a parent of *any* other chain. Could be an L1 or an L2 chain.
+diff --git a/node_modules/@arbitrum/sdk/dist/lib/message/L1ToL2MessageGasEstimator.js b/node_modules/@arbitrum/sdk/dist/lib/message/L1ToL2MessageGasEstimator.js
+index 42adea2..f4d55a7 100644
+--- a/node_modules/@arbitrum/sdk/dist/lib/message/L1ToL2MessageGasEstimator.js
++++ b/node_modules/@arbitrum/sdk/dist/lib/message/L1ToL2MessageGasEstimator.js
+@@ -184,7 +184,11 @@ class L1ToL2MessageGasEstimator {
+             // ethersjs currently doesnt throw for custom solidity errors, so we shouldn't end up here
+             // however we try to catch and parse the error anyway in case ethersjs changes
+             // behaviour and we dont pick up on it
+-            retryable = retryableData_1.RetryableDataTools.tryParseError(err);
++
++            //in case of error thrown by MetamasK
++            const res = err.error?.data?.originalError?.data ?? err
++
++            retryable = retryableData_1.RetryableDataTools.tryParseError(res);
+             if (!(0, lib_1.isDefined)(retryable)) {
+                 throw new errors_1.ArbSdkError('No retryable data found in error', err);
+             }


### PR DESCRIPTION
fix(@arbitrum/sdk): patch L1ToL2MessageGasEstimator to handle Metamask-specific error format