### PR TITLE
Fix: Add right values of hardhat to deploy to the g7 testnet chain

### DIFF
--- a/web3/constants/network.ts
+++ b/web3/constants/network.ts
@@ -18,16 +18,15 @@ export enum ChainId {
     Ethereum = 1,
     Goerli = 5,
     Sepolia = 11155111,
-    ZkSync = 324,
-    ZkSyncSepolia = 300,
     ArbitrumOne = 42161,
     ArbitrumSepolia = 421614,
     OPMainnet = 10,
     OPSepolia = 11155420,
     Base = 8453,
     BaseSepolia = 84532,
-    Game7OrbitArbSepolia = 7007007,
-    Game7OrbitBaseSepolia = 7770007,
+    Game7Testnet = 13746,
+    Linea = 59144,
+    LineaSepolia = 59141,
 }
 
 export enum NetworkName {
@@ -40,16 +39,15 @@ export enum NetworkName {
     Sepolia = 'sepolia',
     Mantle = 'mantle',
     MantleSepolia = 'mantleSepolia',
-    ZkSync = 'zkSync',
-    ZkSyncSepolia = 'zkSyncSepolia',
     ArbitrumOne = 'arbitrumOne',
     ArbitrumSepolia = 'arbitrumSepolia',
     OPMainnet = 'OPMainnet',
     OPSepolia = 'OPSepolia',
     Base = 'base',
     BaseSepolia = 'baseSepolia',
-    Game7OrbitArbSepolia = 'game7OrbitArbSepolia',
-    Game7OrbitBaseSepolia = 'game7OrbitBaseSepolia',
+    Game7Testnet = 'game7Testnet',
+    LineaSepolia = 'lineaSepolia',
+    Linea = 'linea',
 }
 
 export enum NetworkConfigFile {
@@ -63,16 +61,15 @@ export enum NetworkConfigFile {
     Sepolia = 'hardhat.config.ts',
     Mantle = 'mantle.config.ts',
     MantleSepolia = 'mantle.config.ts',
-    ZkSync = 'zkSync.config.ts',
-    ZkSyncSepolia = 'zkSync.config.ts',
     ArbitrumOne = 'arbitrum.config.ts',
     ArbitrumSepolia = 'arbitrum.config.ts',
     OPMainnet = 'op.config.ts',
     OPSepolia = 'op.config.ts',
     Base = 'base.config.ts',
     BaseSepolia = 'base.config.ts',
-    Game7OrbitArbSepolia = 'g7.config.ts',
-    Game7OrbitBaseSepolia = 'g7.config.ts',
+    Game7Testnet = 'g7.config.ts',
+    Linea = 'linea.config.ts',
+    LineaSepolia = 'linea.config.ts',
 }
 
 export enum Currency {
@@ -85,17 +82,15 @@ export enum Currency {
     Sepolia = 'ETH',
     Mantle = 'MNT',
     MantleSepolia = 'MNT',
-    ZkSync = 'ETH',
-    ZkSyncSepolia = 'ETH',
     ArbitrumOne = 'ETH',
     ArbitrumSepolia = 'ETH',
     OPMainnet = 'ETH',
     OPSepolia = 'ETH',
     Base = 'ETH',
     BaseSepolia = 'ETH',
-    Game7Sepolia = 'ETH',
-    Game7OrbitArbSepolia = 'Iron',
-    Game7OrbitBaseSepolia = 'Iron',
+    Game7Testnet = 'TG7T',
+    Linea = 'ETH',
+    LineaSepolia = 'ETH',
 }
 
 export enum NetworkExplorer {
@@ -108,17 +103,15 @@ export enum NetworkExplorer {
     Sepolia = 'https://sepolia.etherscan.io',
     Mantle = 'https://explorer.mantle.xyz',
     MantleSepolia = 'https://explorer.sepolia.mantle.xyz',
-    ZkSync = 'https://explorer.zksync.io',
-    ZkSyncSepolia = 'https://zksync-sepolia.blockscout.com',
     ArbitrumOne = 'https://arbiscan.io',
     ArbitrumSepolia = 'https://sepolia.arbiscan.io',
     OPMainnet = 'https://optimistic.etherscan.io',
     OPSepolia = 'https://sepolia-optimistic.etherscan.io',
     Base = 'https://basescan.org',
     BaseSepolia = 'https://base-sepolia.blockscout.com',
-    //  this will change to: testnet.explorer.game7.io
-    Game7OrbitArbSepolia = 'https://explorerl2new-game7-arb-anytrust-wcj9hysn7y.t.conduit.xyz',
-    Game7OrbitBaseSepolia = 'https://explorerl2new-game7-base-anytrust-zuthm7ggv0.t.conduit.xyz',
+    Game7Testnet = 'https://testnet.game7.io',
+    Linea = 'https://api.lineascan.build',
+    LineaSepolia = 'https://api.sepolia.lineascan.build',
 }
 
 export function getTransactionUrl(txHash: string, network: NetworkName): string {
@@ -138,15 +131,13 @@ export const rpcUrls = {
     [ChainId.PolygonMumbai]: 'https://rpc.ankr.com/polygon_mumbai',
     [ChainId.Mantle]: 'https://rpc.mantle.xyz',
     [ChainId.MantleSepolia]: 'https://rpc.sepolia.mantle.xyz',
-    [ChainId.ZkSync]: 'https://mainnet.era.zksync.io',
-    [ChainId.ZkSyncSepolia]: 'https://sepolia.era.zksync.dev',
     [ChainId.ArbitrumOne]: 'https://arb1.arbitrum.io/rpc',
     [ChainId.ArbitrumSepolia]: 'https://sepolia-rollup.arbitrum.io/rpc',
     [ChainId.OPMainnet]: 'https://mainnet.optimism.io',
     [ChainId.OPSepolia]: 'https://sepolia.optimism.io',
     [ChainId.Base]: 'https://mainnet.base.org',
     [ChainId.BaseSepolia]: 'https://sepolia.base.org',
-    //  this will change to: rpc.sepolia.game7.io
-    [ChainId.Game7OrbitArbSepolia]: 'https://rpc-game7-arb-anytrust-wcj9hysn7y.t.conduit.xyz',
-    [ChainId.Game7OrbitBaseSepolia]: 'https://rpc-game7-base-anytrust-zuthm7ggv0.t.conduit.xyz',
+    [ChainId.Game7Testnet]: 'https://testnet-rpc.game7.io',
+    [ChainId.Linea]: 'https://rpc.linea.build',
+    [ChainId.LineaSepolia]: 'https://rpc.sepolia.linea.build',
 };

--- a/web3/hardhat.config.ts
+++ b/web3/hardhat.config.ts
@@ -46,19 +46,11 @@ const config: HardhatUserConfig = {
         },
         customChains: [
             {
-                network: NetworkName.Game7OrbitArbSepolia,
-                chainId: ChainId.Game7OrbitArbSepolia,
+                network: NetworkName.Game7Testnet,
+                chainId: ChainId.Game7Testnet,
                 urls: {
-                    apiURL: `${NetworkExplorer.Game7OrbitArbSepolia}/api`,
-                    browserURL: NetworkExplorer.Game7OrbitArbSepolia,
-                },
-            },
-            {
-                network: NetworkName.Game7OrbitBaseSepolia,
-                chainId: ChainId.Game7OrbitBaseSepolia,
-                urls: {
-                    apiURL: `${NetworkExplorer.Game7OrbitBaseSepolia}/api`,
-                    browserURL: NetworkExplorer.Game7OrbitBaseSepolia,
+                    apiURL: `${NetworkExplorer.Game7Testnet}/api`,
+                    browserURL: NetworkExplorer.Game7Testnet,
                 },
             },
         ],
@@ -72,13 +64,9 @@ const config: HardhatUserConfig = {
             chainId: ChainId.ArbitrumOne,
             url: rpcUrls[ChainId.ArbitrumOne],
         },
-        [NetworkName.Game7OrbitArbSepolia]: {
-            url: rpcUrls[ChainId.Game7OrbitArbSepolia],
-            chainId: ChainId.Game7OrbitArbSepolia,
-        },
-        [NetworkName.Game7OrbitBaseSepolia]: {
-            url: rpcUrls[ChainId.Game7OrbitBaseSepolia],
-            chainId: ChainId.Game7OrbitBaseSepolia,
+        [NetworkName.Game7Testnet]: {
+            url: rpcUrls[ChainId.Game7Testnet],
+            chainId: ChainId.Game7Testnet,
         },
         [NetworkName.ArbitrumSepolia]: {
             url: rpcUrls[ChainId.ArbitrumSepolia],

--- a/web3/scripts/bridge-example.md
+++ b/web3/scripts/bridge-example.md
@@ -9,7 +9,7 @@ This checklist describes how to bridge tokens
 ```bash
 export L1_RPC=https://sepolia.infura.io/v3/25531dd362e441289ebba71d0b134a6a
 export L2_RPC=https://sepolia-rollup.arbitrum.io/rpc
-export L3_RPC=https://rpc-game7-testnet-2g3y2k9azw.t.conduit.xyz
+export L3_RPC=https://testnet-rpc.game7.io
 export L1_TOKEN=0xac4d9E47765358f8cbD10D3C14246509E39B6251
 export L1L2_ROUTER=0xce18836b233c83325cc8848ca4487e94c6288264
 export L2L3_ROUTER=0xb43F7D804Ec38B74f9230128D12e1F29590cc65e

--- a/web3/scripts/mock.game7-testnet.md
+++ b/web3/scripts/mock.game7-testnet.md
@@ -25,7 +25,7 @@ Deployment transaction: [`0x036c8cb7d159f7e3d747d2fb6031360818273a1e27d540539c2d
 ### Set up environment variables
 
 ```bash
-export RPC="https://rpc-game7-testnet-0ilneybprf.t.conduit.xyz"
+export RPC="https://testnet-rpc.game7.io"
 export SENDER="<path to keyfile>"
 export SENDER_ADDRESS="$(jq -r .address $SENDER)"
 # The following lines were added in the course of this script

--- a/web3/scripts/staker.game7-testnet.md
+++ b/web3/scripts/staker.game7-testnet.md
@@ -12,7 +12,7 @@ staking pool are transferable. This pool is owned by the zero address, and canno
 ### Set up environment variables
 
 ```bash
-export RPC="https://rpc-game7-testnet-0ilneybprf.t.conduit.xyz"
+export RPC="https://testnet-rpc.game7.io"
 export SENDER="<path to keyfile>"
 # The following lines were added in the course of this script
 export STAKER="0xA1D917972df7E88904A2aaFd92f5c0dF16ABA77e"


### PR DESCRIPTION
This pull request includes significant updates to the `web3/constants/network.ts` and `web3/hardhat.config.ts` files, focusing on modifying network configurations and constants. The most important changes involve the removal of ZkSync and Game7Orbit networks and the addition of new networks such as Game7Testnet and Linea.

### Network Configuration Updates:

* [`web3/constants/network.ts`](diffhunk://#diff-14b7febf08b5b95687a38e1e4d18e9c7424d49d5504c7ff8b3f8e6cb66daac38L21-R29): Removed `ZkSync` and `Game7Orbit` networks and added `Game7Testnet` and `Linea` networks in multiple enums (`ChainId`, `NetworkName`, `NetworkConfigFile`, `Currency`, `NetworkExplorer`, `rpcUrls`). [[1]](diffhunk://#diff-14b7febf08b5b95687a38e1e4d18e9c7424d49d5504c7ff8b3f8e6cb66daac38L21-R29) [[2]](diffhunk://#diff-14b7febf08b5b95687a38e1e4d18e9c7424d49d5504c7ff8b3f8e6cb66daac38L43-R50) [[3]](diffhunk://#diff-14b7febf08b5b95687a38e1e4d18e9c7424d49d5504c7ff8b3f8e6cb66daac38L66-R72) [[4]](diffhunk://#diff-14b7febf08b5b95687a38e1e4d18e9c7424d49d5504c7ff8b3f8e6cb66daac38L88-R93) [[5]](diffhunk://#diff-14b7febf08b5b95687a38e1e4d18e9c7424d49d5504c7ff8b3f8e6cb66daac38L111-R114) [[6]](diffhunk://#diff-14b7febf08b5b95687a38e1e4d18e9c7424d49d5504c7ff8b3f8e6cb66daac38L141-R142)

### Hardhat Configuration Changes:

* [`web3/hardhat.config.ts`](diffhunk://#diff-617c9f5b6ca0428a62dc10e440afb7cad076b43e3ead254aaea42589a88a6f7cL49-R53): Updated the custom chains and network configurations to replace `Game7Orbit` networks with `Game7Testnet`. [[1]](diffhunk://#diff-617c9f5b6ca0428a62dc10e440afb7cad076b43e3ead254aaea42589a88a6f7cL49-R53) [[2]](diffhunk://#diff-617c9f5b6ca0428a62dc10e440afb7cad076b43e3ead254aaea42589a88a6f7cL75-R69)