### PR TITLE
localStorage key uses "address" rather than "connectedAccount"

### DIFF
--- a/webapps/world-builder-dashboard/src/components/faucet/FaucetView.tsx
+++ b/webapps/world-builder-dashboard/src/components/faucet/FaucetView.tsx
@@ -105,14 +105,14 @@ const FaucetView: React.FC<FaucetViewProps> = ({}) => {
     {
       onSuccess: (data: TransactionRecord | undefined, { address }) => {
         try {
-          const transactionsString = localStorage.getItem(`bridge-${connectedAccount}-transactions-${selectedNetworkType}`)
+          const transactionsString = localStorage.getItem(`bridge-${address}-transactions-${selectedNetworkType}`)
 
           let transactions = []
           if (transactionsString) {
             transactions = JSON.parse(transactionsString)
           }
           transactions.push({ ...data })
-          localStorage.setItem(`bridge-${connectedAccount}-transactions-${selectedNetworkType}`, JSON.stringify(transactions))
+          localStorage.setItem(`bridge-${address}-transactions-${selectedNetworkType}`, JSON.stringify(transactions))
         } catch (e) {
           console.log(e)
         }


### PR DESCRIPTION
This makes it so that the completion notification shows up for both workflows:
1. Connect account and request funds
2. Paste address and request funds (notification wasn't showing up for this flow before)