### PR TITLE
Fix: Hide canonical bridge button and replace with relay bridge

### DIFF
--- a/webapps/world-builder-dashboard/src/layouts/MainLayout/MainLayout.tsx
+++ b/webapps/world-builder-dashboard/src/layouts/MainLayout/MainLayout.tsx
@@ -81,7 +81,7 @@ const MainLayout: React.FC<MainLayoutProps> = ({ }) => {
   ]
 
   const MAINNET_NAVIGATION_ITEMS: NavigationItem[] = [
-    {
+  /*   {
       name: 'bridge',
       navigateTo: '/bridge',
       Icon: ({ isHovered }: { isHovered?: boolean }) => (
@@ -90,10 +90,10 @@ const MainLayout: React.FC<MainLayoutProps> = ({ }) => {
           stroke={location.pathname.startsWith('/bridge') ? '#fff' : '#B9B9B9'} isHovered={isHovered}
         />
       )
-    },
+    }, */
     {
-      name: 'relay bridge',
-      navigateTo: '/relay',
+      name: 'bridge',
+      navigateTo: '/bridge',
       Icon: ({ isHovered }: { isHovered?: boolean }) => (
         <IconRelay
           className={styles.icomButton}

--- a/webapps/world-builder-dashboard/src/pages/RelayPage/RelayPage.tsx
+++ b/webapps/world-builder-dashboard/src/pages/RelayPage/RelayPage.tsx
@@ -14,7 +14,7 @@ import { useBridgeNotificationsContext } from '@/contexts/BridgeNotificationsCon
 import { useNotifications, usePendingTransactions } from '@/hooks/useL2ToL1MessageStatus'
 import { SwapWidget } from '@reservoir0x/relay-kit-ui'
 import { Address } from "viem"
-import { useNavigate } from 'react-router-dom'
+//import { useNavigate } from 'react-router-dom'
 import { G7_ARB, G7_G7, TOKENS } from '@/utils/relayConfig'
 export interface SwapWidgetToken {
     chainId: number;
@@ -28,7 +28,7 @@ export interface SwapWidgetToken {
 
 const RelayPage = () => {
     const { connectedAccount, connectWallet } = useBlockchainContext()
-    const navigate = useNavigate()
+    //const navigate = useNavigate()
     const pendingTransacions = usePendingTransactions(connectedAccount)
     const [notificationsOffset] = useState(0)
     const [notificationsLimit] = useState(10)

--- a/webapps/world-builder-dashboard/src/pages/RelayPage/RelayPage.tsx
+++ b/webapps/world-builder-dashboard/src/pages/RelayPage/RelayPage.tsx
@@ -74,9 +74,9 @@ const RelayPage = () => {
                         }}
                         tokens={TOKENS}
                     />
-                    <div className={styles.canonicalLink} onClick={() => navigate('/bridge')}>
+                  {/*   <div className={styles.canonicalLink} onClick={() => navigate('/bridge')}>
                         Bridge with Canonical
-                    </div>
+                    </div> */}
                 </div>
             </div>
         </div>

--- a/webapps/world-builder-dashboard/src/router.tsx
+++ b/webapps/world-builder-dashboard/src/router.tsx
@@ -2,7 +2,7 @@ import { createBrowserRouter } from 'react-router-dom'
 import ErrorBoundary from '@/components/ErrorBoundry'
 //Layouts
 import MainLayout from '@/layouts/MainLayout/MainLayout'
-import BridgePage from '@/pages/BridgePage/BridgePage'
+//import BridgePage from '@/pages/BridgePage/BridgePage'
 import FaucetPage from '@/pages/FaucetPage/FaucetPage'
 //Pages
 import NotFoundPage from '@/pages/NotFoundPage/NotFoundPage'

--- a/webapps/world-builder-dashboard/src/router.tsx
+++ b/webapps/world-builder-dashboard/src/router.tsx
@@ -32,7 +32,7 @@ const router = createBrowserRouter([
     path: '/cookie',
     errorElement: <ErrorBoundary />
   },
-  {
+ /*  {
     element: <MainLayout />,
     children: [
       {
@@ -40,13 +40,22 @@ const router = createBrowserRouter([
         element: <BridgePage />
       }
     ]
-  },
+  }, */
   {
     element: <MainLayout />,
     children: [
       {
         path: '/faucet/*',
         element: <FaucetPage />
+      }
+    ]
+  },
+  {
+    element: <MainLayout />,
+    children: [
+      {
+        path: '/bridge/*',
+        element: <RelayPage />
       }
     ]
   },


### PR DESCRIPTION
This pull request refactors navigation and routing in the `world-builder-dashboard` to replace the `/bridge` route with the `/relay` route, deprecating the canonical bridge functionality. The most important changes include commenting out the old `/bridge` route and related components, updating navigation items to reflect the new route, and introducing the `/relay` route in the router configuration.

### Navigation and Layout Updates:
* [`webapps/world-builder-dashboard/src/layouts/MainLayout/MainLayout.tsx`](diffhunk://#diff-ae70061bc721ea941389e4ca0de2ee887cfc4bec8b4c5f6183cdc34ced276742L84-R84): Commented out the old `/bridge` navigation item and updated the navigation to point to the `/relay` route instead. [[1]](diffhunk://#diff-ae70061bc721ea941389e4ca0de2ee887cfc4bec8b4c5f6183cdc34ced276742L84-R84) [[2]](diffhunk://#diff-ae70061bc721ea941389e4ca0de2ee887cfc4bec8b4c5f6183cdc34ced276742L93-R96)

### Routing Updates:
* [`webapps/world-builder-dashboard/src/router.tsx`](diffhunk://#diff-1ec32b9756f668f0b8c415d92caaf57b7fbdd93e2253694c56959f043e188802L35-R43): Commented out the `/bridge` route configuration and added a new `/relay` route pointing to `RelayPage`. [[1]](diffhunk://#diff-1ec32b9756f668f0b8c415d92caaf57b7fbdd93e2253694c56959f043e188802L35-R43) [[2]](diffhunk://#diff-1ec32b9756f668f0b8c415d92caaf57b7fbdd93e2253694c56959f043e188802R53-R61)

### Component Changes:
* [`webapps/world-builder-dashboard/src/pages/RelayPage/RelayPage.tsx`](diffhunk://#diff-6ab0229845840cfe3a37447ccc6a65dde93b48a25fbd43bb5b2107028cc1df15L77-R79): Commented out the canonical bridge link within the RelayPage component.